### PR TITLE
allow child entities tabs to be ordered according to their rank set i…

### DIFF
--- a/macros_noticejuridique.html
+++ b/macros_noticejuridique.html
@@ -144,11 +144,11 @@
  * Textes enfants de la noticejuridique.
  */
 <DEFMACRO NAME="NOTICEJURIDIQUE_TEXTES">
-	<LET VAR="noticejuridique_textes_order">type, rank</LET>
+	<LET VAR="noticejuridique_textes_order">alias_entities_textes.rank</LET>
 	<LET VAR="noticejuridique_tabs_prefix">noticejuridique-textes-tab-</LET>
 
 	<section class="noticejuridique__textes article__text">
-		<LOOP NAME="noticejuridique_textes" TABLE="textes" WHERE="idparent = '[#ID]'" ORDER="'[#NOTICEJURIDIQUE_TEXTES_ORDER]'">
+		<LOOP NAME="noticejuridique_textes" TABLE="textes" WHERE="idparent = '[#ID]'" ORDER="[#NOTICEJURIDIQUE_TEXTES_ORDER]">
 			<BEFORE>
 				<FUNC NAME="NOTICEJURIDIQUE_TEXTES_SECTION_HEADER" TITLE="[@TEXTES]" />
 				<MACRO NAME="NOTICEJURIDIQUE_TEXTES_TABS"/>
@@ -201,7 +201,7 @@
  * Onglets des textes enfants de la noticejuridique.
  */
 <DEFMACRO NAME="NOTICEJURIDIQUE_TEXTES_TABS">
-	<LOOP NAME="noticejuridique_textes_tabs" TABLE="textes" WHERE="idparent = '[#ID]'" SELECT="id, type, titre" ORDER="'[#NOTICEJURIDIQUE_TEXTES_ORDER]'">
+	<LOOP NAME="noticejuridique_textes_tabs" TABLE="textes" WHERE="idparent = '[#ID]'" SELECT="id, type, titre" ORDER="[#NOTICEJURIDIQUE_TEXTES_ORDER]">
 		<BEFORE>
 			<ul class="nav nav-tabs" role="tablist">
 				<!--[ Résumé de la noticejuridique ]-->


### PR DESCRIPTION
Bonjour Thomas,
Actuellement les onglets qui contiennent les entités textes enfants d'une notice juridique (conclusions et notes) sont affichés dans l'ordre de création de ces entités. 
C'est souvent les Conclusions qui sont le 1er texte enfant créé, mais ce n'est pas toujours le cas et les utlisateurs d'Alyoda souhaiteraient pouvoir afficher conventionellement l'onglet Conclusions à la suite immédiate du Résumé.
La modification proposée permettrait de pouvoir modifier l'ordre par défaut via les petites flèches de l'interface Edition.
J'ai juste un doute sur d'éventuels effets de bord.

Olivier Crouzet